### PR TITLE
refactored posts to use svelte readable store

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,38 +1,10 @@
 <script>
 	import { Router, Link, Route } from "svelte-routing"
+	import { posts, links } from './stores.js'
 	import Title from './components/Title.svelte'
 	import Social from './components/Social.svelte'
 	import Date from './components/Date.svelte'
 	import Post from './Post.svelte'
-
-	let links = [
-		{
-			name: "GitHub",
-			href: "https://github.com/wperron",
-		},
-		{
-			name: "Twitter",
-			href: "https://twitter.com/_wperron",
-		},
-	]
-
-	let promise = fetchPosts()
-	let posts = null
-
-	async function fetchPosts() {
-		let res = await fetch('/posts.json')
-			.then(res => res.json())
-		posts = res
-		return res
-	}
-
-	function getPostBySlug(slug) {
-		const match = posts.filter(post => post.attributes.slug === slug)
-		if (match.length > 1) {
-			throw new Error('Found more than one slug, expected only one.')
-		}
-		return match[0]
-	}
 </script>
 
 <main>
@@ -42,24 +14,18 @@
 		<Route path="/">
 			<Social links={links} />
 			<hr />
-			{#await promise}
-				<p>waiting...</p>
-			{:then posts}
-				{#each posts as post}
-					<div class='content-item'>
-						<Link to={`/blog/${post.attributes.slug}`}>
-							<span class='content-title'>{post.attributes.title}</span>
-						</Link>
-						<Date date={post.attributes.date} />
-						<p class='content-text'>{post.attributes.description}</p>
-					</div>
-				{/each}
-			{:catch err}
-				<p>Oops, something went wrong... 😬</p>
-			{/await}
+			{#each $posts as post}
+				<div class='content-item'>
+					<Link to={`/blog/${post.attributes.slug}`}>
+						<span class='content-title'>{post.attributes.title}</span>
+					</Link>
+					<Date date={post.attributes.date} />
+					<p class='content-text'>{post.attributes.description}</p>
+				</div>
+			{/each}
 		</Route>
 		<Route path="blog/:slug" let:params>
-			<Post post={getPostBySlug(params.slug)} />
+			<Post slug={params.slug} />
 		</Route>
 	</Router>
 </main>

--- a/src/Post.svelte
+++ b/src/Post.svelte
@@ -1,7 +1,17 @@
 <script>
+	import { posts } from './stores.js'
 	import Date from './components/Date.svelte'
 
-	export let post
+	export let slug
+
+	let post = null
+	const unsubscribe = posts.subscribe(all => {
+		const match = all.filter(x => x.attributes.slug === slug)
+		if (match.length > 1) {
+			throw new Error('Found more than one lsug, expected only one.')
+		}
+		post = match[0]
+	})
 </script>
 
 <div class='blog-post'>

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,0 +1,22 @@
+import { readable } from 'svelte/store';
+
+export const posts = readable([], async function start(set) {
+	const res = await fetch('/posts.json')
+		.then(res => res.json())
+	set(res)
+
+	return function stop() {
+		return
+	}
+})
+
+export const links = [
+	{
+		name: "GitHub",
+		href: "https://github.com/wperron",
+	},
+	{
+		name: "Twitter",
+		href: "https://twitter.com/_wperron",
+	},
+]


### PR DESCRIPTION
Refactored the posts fetch operation to a readable store
and removed the {#await} block since it was no longer used.

Also refactored the links to the same store file for cleanliness.

Closes #2